### PR TITLE
fix: use proper gem jekyll_picture_tag, broken link

### DIFF
--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -4,6 +4,7 @@ gem 'jekyll-paginate-v2'
 gem 'jekyll-language-plugin'
 gem 'jekyll-sitemap'
 gem 'jekyll-seo-tag'
+gem 'kramdown-parser-gfm'
 group :jekyll_plugins do
-  gem 'jekyll-picture-tag', git: 'https://github.com/robwierzbowski/jekyll-picture-tag/'
+  gem 'jekyll_picture_tag', '~> 1.10.2'
 end

--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -6,5 +6,5 @@ gem 'jekyll-sitemap'
 gem 'jekyll-seo-tag'
 gem 'kramdown-parser-gfm'
 group :jekyll_plugins do
-  gem 'jekyll_picture_tag', '~> 1.10.2'
+  gem 'jekyll_picture_tag', '1.10.2'
 end

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -5,7 +5,7 @@ plugins:
 - jekyll-language-plugin
 - jekyll-sitemap
 - jekyll-seo-tag
-- jekyll-picture-tag
+- jekyll_picture_tag
 - jekyll-paginate-v2
 
 language_data: data.%%

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -20,7 +20,7 @@ title: Home
 
     <section id="ksi" class="wrapper spotlight style3">
         <div class="inner">
-            {% picture logo images/base/logo-ksi.png --link /about/ --a class="image" %}
+            {% picture logo images/base/logo-ksi.png --link /{{ page.language }}/about/ --a class="image" %}
             <div class="content">
                 <h2 class="major">{% t 'section_ksi.title' %}</h2>
                 <p>{% t 'section_ksi.text' %}</p>


### PR DESCRIPTION
### Jekyll_picture_tag version
- Jekyll now always use supported version of `jekyll_picture_tag` (1.10.2)
- Name of gem was changed from `jekyll-picture-tag` to `jekyll_picture_tag`
- That is changed to be able to test page locally
### Broken link
- Fixed broken link to about page
### PR main purpose
- This PR is mostly to check if basic changes work